### PR TITLE
Initial support for helm3

### DIFF
--- a/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/HelmTask.java
+++ b/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/HelmTask.java
@@ -1,0 +1,24 @@
+package ca.vanzyl.concord.plugins.k8s.helm3;
+
+import ca.vanzyl.concord.plugins.tool.ToolCommand;
+import ca.vanzyl.concord.plugins.tool.ToolInitializer;
+import ca.vanzyl.concord.plugins.tool.ToolTaskSupport;
+import com.walmartlabs.concord.sdk.InjectVariable;
+import com.walmartlabs.concord.sdk.LockService;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Map;
+
+@Named("helm3")
+public class HelmTask extends ToolTaskSupport {
+
+    @InjectVariable("defaults")
+    private Map<String, Object> defaults;
+
+    @Inject
+    public HelmTask(Map<String, ToolCommand> commands, LockService lockService, ToolInitializer toolInitializer) {
+        super(commands, lockService, toolInitializer);
+    }
+}
+

--- a/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/commands/Install.java
+++ b/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/commands/Install.java
@@ -1,0 +1,69 @@
+package ca.vanzyl.concord.plugins.k8s.helm3.commands;
+
+import ca.vanzyl.concord.plugins.k8s.helm3.config.Chart;
+import ca.vanzyl.concord.plugins.tool.ToolCommandSupport;
+import ca.vanzyl.concord.plugins.tool.annotations.Flag;
+import ca.vanzyl.concord.plugins.tool.annotations.Omit;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.walmartlabs.concord.sdk.Context;
+
+import javax.inject.Named;
+import java.io.File;
+import java.nio.file.Path;
+
+@Named("helm3/install")
+public class Install extends ToolCommandSupport {
+
+    @JsonProperty("chart")
+    @Omit
+    private Chart chart;
+
+    public Chart chart() {
+        return chart;
+    }
+
+
+    @JsonProperty("atomic")
+    @Flag(name = {"--atomic"})
+    private boolean atomic = true;
+
+    @Override
+    public String idempotencyCheckCommand(Context context) {
+        return String.format("{{executable}} status %s", chart.name());
+    }
+
+    @Override
+    public void preProcess(Path workDir, Context context) {
+
+        if (chart.values() != null) {
+            interpolateWorkspaceFileAgainstContext(new File(chart.values()), context);
+        }
+
+        //
+        // Patrick uses this to modify the version in the Chart.yml when deploying new versions
+        //
+        // Here is where we want to alter what Helm install is doing. If there is an externals configuration we want
+        // fetch the Helm chart, insert the externals into the Helm chart and then install from the directory we
+        // created with the fetched Helm chart
+        //
+        // - do any preparation work here and run any commands necessary. i need the path to the executable and access
+        //   to the command and its configuration
+        // - change the command line arguments as necessary. in the case of Helm we need to install from the directory
+        //   just created.
+        //
+        /*
+        if(chart.externals() != null) {
+            //
+            // helm fetch --version 1.7.4 --untar --untardir jenkins stable/jenkins
+            //
+            Path untardir = workDir(context).resolve("chart-" + chart.name());
+            //
+            // 1 = version
+            // 2 = untardir
+            // 3 = chart
+            //
+            String.format("{{executable}} fetch --version %s --untar --untardir %s %s", chart.version(), chart.name(), chart.value());
+        }
+         */
+    }
+}

--- a/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/commands/Repo.java
+++ b/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/commands/Repo.java
@@ -1,0 +1,23 @@
+package ca.vanzyl.concord.plugins.k8s.helm3.commands;
+
+import ca.vanzyl.concord.plugins.k8s.helm3.config.Add;
+import ca.vanzyl.concord.plugins.k8s.helm3.config.Update;
+import ca.vanzyl.concord.plugins.tool.ToolCommandSupport;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.inject.Named;
+
+@Named("helm3/repo")
+public class Repo extends ToolCommandSupport {
+
+    @JsonProperty
+    private Add add;
+
+    public Add add() { return add; }
+
+    @JsonProperty
+    private Update update;
+
+    public Update update() {return update;}
+
+}

--- a/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/commands/Upgrade.java
+++ b/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/commands/Upgrade.java
@@ -1,0 +1,67 @@
+package ca.vanzyl.concord.plugins.k8s.helm3.commands;
+
+import ca.vanzyl.concord.plugins.k8s.helm3.config.Chart;
+import ca.vanzyl.concord.plugins.tool.ToolCommandSupport;
+import ca.vanzyl.concord.plugins.tool.annotations.Flag;
+import ca.vanzyl.concord.plugins.tool.annotations.Omit;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.walmartlabs.concord.sdk.Context;
+
+import javax.inject.Named;
+import java.io.File;
+import java.nio.file.Path;
+
+
+@Named("helm3/upgrade")
+public class Upgrade extends ToolCommandSupport {
+
+    @JsonProperty("install")
+    @Flag(name = {"--install"})
+    private boolean install = true;
+
+    @JsonProperty("atomic")
+    @Flag(name = {"--atomic"})
+    private boolean atomic = true;
+
+    @JsonProperty("chart")
+    @Omit
+    private Chart chart;
+    public Chart chart() {
+        return chart;
+    }
+
+    @Override
+    public void preProcess(Path workDir, Context context) {
+
+        if(chart.values() != null) {
+            interpolateWorkspaceFileAgainstContext(new File(chart.values()), context);
+        }
+
+        //
+        // Patrick uses this to modify the version in the Chart.yml when deploying new versions
+        //
+        // Here is where we want to alter what Helm install is doing. If there is an externals configuration we want
+        // fetch the Helm chart, insert the externals into the Helm chart and then install from the directory we
+        // created with the fetched Helm chart
+        //
+        // - do any preparation work here and run any commands necessary. i need the path to the executable and access
+        //   to the command and its configuration
+        // - change the command line arguments as necessary. in the case of Helm we need to install from the directory
+        //   just created.
+        //
+        /*
+        if(chart.externals() != null) {
+            //
+            // helm fetch --version 1.7.4 --untar --untardir jenkins stable/jenkins
+            //
+            Path untardir = workDir(context).resolve("chart-" + chart.name());
+            //
+            // 1 = version
+            // 2 = untardir
+            // 3 = chart
+            //
+            String.format("{{executable}} fetch --version %s --untar --untardir %s %s", chart.version(), chart.name(), chart.value());
+        }
+         */
+    }
+}

--- a/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/config/Add.java
+++ b/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/config/Add.java
@@ -1,0 +1,19 @@
+package ca.vanzyl.concord.plugins.k8s.helm3.config;
+
+import ca.vanzyl.concord.plugins.tool.annotations.Value;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Add {
+
+    @JsonProperty
+    @Value
+    private String name;
+
+    @JsonProperty
+    @Value
+    private String url;
+
+    public String name() { return name; }
+
+    public String url() { return url; }
+}

--- a/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/config/Chart.java
+++ b/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/config/Chart.java
@@ -1,0 +1,59 @@
+package ca.vanzyl.concord.plugins.k8s.helm3.config;
+
+import ca.vanzyl.concord.plugins.k8s.helm3.commands.Upgrade;
+import ca.vanzyl.concord.plugins.tool.annotations.KeyValue;
+import ca.vanzyl.concord.plugins.tool.annotations.Option;
+import ca.vanzyl.concord.plugins.tool.annotations.Value;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class Chart {
+
+    @JsonProperty
+    @Option(name = {"--namespace"})
+    private String namespace;
+
+    @JsonProperty
+    @Option(name = {"--version"})
+    private String version;
+
+    @JsonProperty
+    @KeyValue(name = "--set")
+    private List<String> set;
+
+    @JsonProperty
+    @Option(name = {"-f"})
+    private String values;
+
+    @JsonProperty
+    @Value
+    private String name;
+
+    @JsonProperty
+    @Value
+    private String value;
+
+    public Chart() {
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String namespace() {
+        return namespace;
+    }
+
+    public String version() {
+        return version;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public String values() {
+        return values;
+    }
+}

--- a/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/config/Update.java
+++ b/src/main/java/ca/vanzyl/concord/plugins/k8s/helm3/config/Update.java
@@ -1,0 +1,12 @@
+package ca.vanzyl.concord.plugins.k8s.helm3.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Update {
+
+    @JsonProperty
+    private String name;
+
+    public String name() { return name; }
+
+}

--- a/src/main/resources/helm3/descriptor.yml
+++ b/src/main/resources/helm3/descriptor.yml
@@ -1,0 +1,9 @@
+---
+id: helm3
+name: Helm3
+executable: helm
+architecture: amd64
+namingStyle: LOWER
+packaging: TARGZ_STRIP
+defaultVersion: v3.1.2
+urlTemplate: https://get.helm.sh/helm-{version}-{os}-{arch}.tar.gz

--- a/src/test/java/ca/vanzyl/concord/plugins/k8s/helm3/Helm3Test.java
+++ b/src/test/java/ca/vanzyl/concord/plugins/k8s/helm3/Helm3Test.java
@@ -1,0 +1,195 @@
+package ca.vanzyl.concord.plugins.k8s.helm3;
+
+import ca.vanzyl.concord.plugins.Configurator;
+import ca.vanzyl.concord.plugins.k8s.helm3.commands.Install;
+import ca.vanzyl.concord.plugins.k8s.helm3.commands.Repo;
+import ca.vanzyl.concord.plugins.k8s.helm3.commands.Upgrade;
+import ca.vanzyl.concord.plugins.tool.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.walmartlabs.concord.plugins.ConcordTestSupport;
+import com.walmartlabs.concord.plugins.InterpolatingMockContext;
+import com.walmartlabs.concord.plugins.OKHttpDownloadManager;
+import com.walmartlabs.concord.sdk.Context;
+import com.walmartlabs.concord.sdk.MockContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.walmartlabs.concord.sdk.Constants.Context.WORK_DIR_KEY;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class Helm3Test extends ConcordTestSupport
+{
+
+    private Configurator toolConfigurator;
+
+    @Before
+    public void setUp() throws Exception {
+        toolConfigurator = new Configurator();
+        super.setUp();
+    }
+
+    @Test
+    public void validateToolInitializerWithHelm() throws Exception {
+
+        Path workingDirectory = Files.createTempDirectory("concord");
+        deleteDirectory(workingDirectory);
+
+        ToolInitializer toolInitializer = new ToolInitializer(new OKHttpDownloadManager("helm"));
+        ToolDescriptor toolDescriptor = ToolTaskSupport.fromResource("helm3");
+        ToolInitializationResult result = toolInitializer.initialize(workingDirectory, toolDescriptor);
+
+        assertTrue(result.executable().toFile().exists());
+        assertTrue(Files.isExecutable(result.executable()));
+
+        deleteDirectory(workingDirectory);
+    }
+
+
+    @Test
+    public void validateHelmInstall() throws Exception {
+
+        ToolInitializer toolInitializer = new ToolInitializer(new OKHttpDownloadManager("helm3"));
+        Map<String, ToolCommand> commands = ImmutableMap.of("helm3/install", new Install());
+        HelmTask task = new HelmTask(commands, lockService, toolInitializer);
+
+        // Create a values.yml file and make sure it's interpolated correctly
+        Path valuesYaml = Files.createTempFile("helm", "values.yaml");
+        System.out.println("Creating Helm values.yml: " + valuesYaml.toString());
+        StringBuffer sb = new StringBuffer();
+        sb.append("ingress:").append("\n");
+        sb.append("  hostname: ${hostname}");
+        Files.write(valuesYaml, sb.toString().getBytes());
+
+        Map<String, Object> args = Maps.newHashMap(mapBuilder()
+                .put(WORK_DIR_KEY, workDir.toAbsolutePath().toString())
+                .put("dryRun", true)
+                .put("command", "install")
+                .put("chart",
+                        mapBuilder()
+                                .put("name", "sealed-secrets")
+                                .put("namespace", "kube-system")
+                                .put("version", "1.4.2")
+                                .put("set", ImmutableList.of("expose.ingress.host.core=bob.fetesting.com"))
+                                .put("value", "stable/sealed-secrets")
+                                .put("values", valuesYaml.toString())
+                                .build())
+                .put("envars",
+                        mapBuilder()
+                                .put("AWS_ACCESS_KEY_ID", "aws-access-key")
+                                .put("AWS_SECRET_ACCESS_KEY", "aws-secret-key")
+                                .put("KUBECONFIG", "/workspace/_attachments/k8s-cluster0-kubeconfig")
+                                .build())
+                .put("hostname", "awesome.concord.io")
+                .build());
+
+        Context context = new InterpolatingMockContext(args);
+        task.execute(context);
+        String commandLine = varAsString(context, "commandLineArguments");
+
+        System.out.println(commandLine);
+
+        // Make sure our values.yaml file was interpolated correctly by the Helm install command
+        String interpolatedContent = new String(Files.readAllBytes(valuesYaml));
+        assertThat(interpolatedContent).contains("hostname: awesome.concord.io");
+
+        String expectedCommandLine = String.format("helm install --namespace kube-system --version 1.4.2 --set expose.ingress.host.core=bob.fetesting.com -f %s sealed-secrets stable/sealed-secrets --atomic", valuesYaml.toString());
+        assertThat(normalizedCommandLineArguments(context)).isEqualTo(expectedCommandLine);
+
+        System.out.println(context.getVariable("envars"));
+
+        // If these were placed in the context, then they were added to the environment of the executed command
+        assertThat(varAsMap(context, "envars").get("KUBECONFIG")).isEqualTo("/workspace/_attachments/k8s-cluster0-kubeconfig");
+        assertThat(varAsMap(context, "envars").get("AWS_ACCESS_KEY_ID")).isEqualTo("aws-access-key");
+        assertThat(varAsMap(context, "envars").get("AWS_SECRET_ACCESS_KEY")).isEqualTo("aws-secret-key");
+    }
+
+    @Test
+    public void validateHelmUpgrade() throws Exception {
+
+        ToolInitializer toolInitializer = new ToolInitializer(new OKHttpDownloadManager("helm3"));
+        Map<String, ToolCommand> commands = ImmutableMap.of("helm3/upgrade", new Upgrade());
+        HelmTask task = new HelmTask(commands, lockService, toolInitializer);
+
+        // Create a values.yml file and make sure it's interpolated correctly
+        Path valuesYaml = Files.createTempFile("helm", "values.yaml");
+        System.out.println("Creating Helm values.yml: " + valuesYaml.toString());
+        StringBuffer sb = new StringBuffer();
+        sb.append("ingress:").append("\n");
+        sb.append("  hostname: ${hostname}");
+        Files.write(valuesYaml, sb.toString().getBytes());
+
+        Map<String, Object> args = Maps.newHashMap(mapBuilder()
+                .put(WORK_DIR_KEY, workDir.toAbsolutePath().toString())
+                .put("dryRun", true)
+                .put("command", "upgrade")
+                .put("chart",
+                        mapBuilder()
+                                .put("name", "sealed-secrets")
+                                .put("namespace", "kube-system")
+                                .put("version", "1.4.2")
+                                .put("set", ImmutableList.of("expose.ingress.host.core=bob.fetesting.com"))
+                                .put("value", "stable/sealed-secrets")
+                                .put("values", valuesYaml.toString())
+                                .build())
+                .put("envars",
+                        mapBuilder()
+                                .put("AWS_ACCESS_KEY_ID", "aws-access-key")
+                                .put("AWS_SECRET_ACCESS_KEY", "aws-secret-key")
+                                .put("KUBECONFIG", "/workspace/_attachments/k8s-cluster0-kubeconfig")
+                                .build())
+                .put("hostname", "awesome.concord.io")
+                .build());
+
+        Context context = new InterpolatingMockContext(args);
+        task.execute(context);
+        String commandLine = varAsString(context, "commandLineArguments");
+
+        System.out.println(commandLine);
+
+        // Make sure our values.yaml file was interpolated correctly by the Helm install command
+        String interpolatedContent = new String(Files.readAllBytes(valuesYaml));
+        assertThat(interpolatedContent).contains("hostname: awesome.concord.io");
+
+        String expectedCommandLine = String.format("helm upgrade --install --atomic --namespace kube-system --version 1.4.2 --set expose.ingress.host.core=bob.fetesting.com -f %s sealed-secrets stable/sealed-secrets", valuesYaml.toString());
+        assertThat(normalizedCommandLineArguments(context)).isEqualTo(expectedCommandLine);
+
+        System.out.println(context.getVariable("envars"));
+
+        // If these were placed in the context, then they were added to the environment of the executed command
+        assertThat(varAsMap(context, "envars").get("KUBECONFIG")).isEqualTo("/workspace/_attachments/k8s-cluster0-kubeconfig");
+        assertThat(varAsMap(context, "envars").get("AWS_ACCESS_KEY_ID")).isEqualTo("aws-access-key");
+        assertThat(varAsMap(context, "envars").get("AWS_SECRET_ACCESS_KEY")).isEqualTo("aws-secret-key");
+    }
+
+    @Test
+    public void validateHelmAddRepo() throws Exception {
+
+        ToolInitializer toolInitializer = new ToolInitializer(new OKHttpDownloadManager("helm3"));
+        Map<String, ToolCommand> commands = ImmutableMap.of("helm3/repo", new Repo());
+        HelmTask task = new HelmTask(commands, lockService, toolInitializer);
+
+        Map<String, Object> args = Maps.newHashMap(mapBuilder()
+                .put(WORK_DIR_KEY, workDir.toAbsolutePath().toString())
+                .put("dryRun", true)
+                .put("command", "repo")
+                .put("add",
+                        mapBuilder()
+                                .put("name", "jetstack")
+                                .put("url", "https://charts.jetstack.io")
+                                .build())
+                .build());
+
+        Context context = new MockContext(args);
+        task.execute(context);
+
+        String expectedCommandLine = "helm repo add jetstack https://charts.jetstack.io";
+        assertThat(normalizedCommandLineArguments(context)).isEqualTo(expectedCommandLine);
+    }
+}


### PR DESCRIPTION
can be used using the task as  `helm3`

```
    - task: helm3
      in:
        command: upgrade
        chart:
          name: external-dns
          namespace: external-dns
          version: 2.14.0
          value: stable/external-dns
          values: "${profile}/external-dns/values.yaml"
```